### PR TITLE
Fix:修改後端schedule跟schedulePlaces邏輯

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ import { config } from "./config.js";
 
 const app = express();
 dotenv.config();
-const HOST_URL = process.env.HOST_URL;
+const HOST_URL = process.env.HOST_URL || "http://localhost:5173";
 
 app.use(
   session({
@@ -34,12 +34,12 @@ app.use(
     methods: ["GET", "POST", "PATCH", "DELETE"],
   })
 );
-// app.use((req, res, next) => {
-//   res.setHeader("Access-Control-Allow-Origin", "*");
-//   res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
-//   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
-//   next();
-// });
+app.use((req, res, next) => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  next();
+});
 app.use(express.json());
 app.use(passport.initialize());
 app.use(express.urlencoded({ extended: false }));
@@ -50,7 +50,6 @@ app.use("/api/auth", authRoutes);
 app.use("/users", usersRouter);
 app.use("/users", profileRouter);
 app.use("/api/upload", uploadRouter);
-
 
 app.get("/", (req, res) => {
   res.send("Welcome to the API!");
@@ -88,10 +87,9 @@ app.use(
   })
 );
 
-
 app.use("/users", usersRouter);
 app.use("/places", placesRouter);
-app.use("/schedules", schedulesRouter); 
+app.use("/schedules", schedulesRouter);
 app.use("/schedulePlaces", schedulePlaceRouter);
 app.use("/favorites", favoritesRouter);
 // 全局錯誤處理中間件

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,9 @@
         "express-session": "^1.18.1",
         "express-zod-api": "^21.2.0",
         "jsonwebtoken": "^9.0.2",
-
-        "module-alias": "^2.2.3",
         "multer": "^1.4.5-lts.1",
         "multer-s3": "^3.0.1",
+        "nodemon": "^3.1.7",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "passport-line": "^0.0.4",
@@ -3216,11 +3215,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/module-alias": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
-      "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q=="
     },
     "node_modules/ms": {
       "version": "2.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,8 +82,7 @@ model schedule_places {
   arrival_time       DateTime?         @default(dbgenerated("'08:00:00'")) @db.Time(0)
   stay_time          DateTime?         @default(dbgenerated("'01:00:00'")) @db.Time(0)
   transportation_way TransportationWay @default(PUBLIC_TRANSPORT)
-  position           Int               @default(0)
-  order              String?           @unique(map: "order_UNIQUE") @db.VarChar(45)
+  order              Int               @default(0)
   places             places            @relation(fields: [place_id], references: [place_id], onUpdate: Restrict, map: "schedule_place_id")
   schedules          schedules         @relation(fields: [schedule_id], references: [id], onUpdate: Restrict, map: "schedule_schedule_id")
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,14 +76,15 @@ model places_categories {
 
 model schedule_places {
   id                 Int               @id @default(autoincrement())
-  place_id           Int
+  place_id           String
   schedule_id        Int
   which_date         DateTime          @db.Date
   arrival_time       DateTime?         @default(dbgenerated("'08:00:00'")) @db.Time(0)
-  stay_time          DateTime          @default(dbgenerated("'01:00:00'")) @db.Time(0)
+  stay_time          DateTime?         @default(dbgenerated("'01:00:00'")) @db.Time(0)
   transportation_way TransportationWay @default(PUBLIC_TRANSPORT)
-  order              String            @unique(map: "order_UNIQUE") @db.VarChar(45)
-  places             places            @relation(fields: [place_id], references: [id], onUpdate: Restrict, map: "schedule_place_id") // 修改 references 為 place_id
+  position           Int               @default(0)
+  order              String?           @unique(map: "order_UNIQUE") @db.VarChar(45)
+  places             places            @relation(fields: [place_id], references: [place_id], onUpdate: Restrict, map: "schedule_place_id")
   schedules          schedules         @relation(fields: [schedule_id], references: [id], onUpdate: Restrict, map: "schedule_schedule_id")
 
   @@index([place_id], map: "schedule_place_id_idx")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,14 +76,14 @@ model places_categories {
 
 model schedule_places {
   id                 Int               @id @default(autoincrement())
-  place_id           String
+  place_id           Int
   schedule_id        Int
   which_date         DateTime          @db.Date
   arrival_time       DateTime?         @default(dbgenerated("'08:00:00'")) @db.Time(0)
   stay_time          DateTime          @default(dbgenerated("'01:00:00'")) @db.Time(0)
   transportation_way TransportationWay @default(PUBLIC_TRANSPORT)
   order              String            @unique(map: "order_UNIQUE") @db.VarChar(45)
-  places             places            @relation(fields: [place_id], references: [place_id], onUpdate: Restrict, map: "schedule_place_id") // 修改 references 為 place_id
+  places             places            @relation(fields: [place_id], references: [id], onUpdate: Restrict, map: "schedule_place_id") // 修改 references 為 place_id
   schedules          schedules         @relation(fields: [schedule_id], references: [id], onUpdate: Restrict, map: "schedule_schedule_id")
 
   @@index([place_id], map: "schedule_place_id_idx")

--- a/src/routes/schedulePlaces.js
+++ b/src/routes/schedulePlaces.js
@@ -1,9 +1,11 @@
-import express from 'express';
-import {prisma} from '../configs/db.js';
+import express from "express";
+import { prisma } from "../configs/db.js";
+import { authenticate } from "../middlewares/auth.js";
+import { verifyOwner } from "../middlewares/verifyOwner.js";
 
 const router = express.Router();
 
-router.get('/', async (req, res) => {
+router.get("/", async (req, res) => {
   try {
     const schedulePlaces = await prisma.schedule_places.findMany({
       include: {
@@ -13,11 +15,11 @@ router.get('/', async (req, res) => {
     });
     res.status(200).json(schedulePlaces);
   } catch (err) {
-    res.status(500).json({ error: '無法取得資料' });
+    res.status(500).json({ error: "無法取得資料" });
   }
 });
 
-router.post('/', async (req, res) => {
+router.post("/", async (req, res) => {
   const {
     place_id,
     schedule_id,
@@ -25,7 +27,7 @@ router.post('/', async (req, res) => {
     arrival_time,
     stay_time,
     transportation_way,
-    order
+    order,
   } = req.body;
   try {
     const arrivalDateTime = new Date(`${which_date}T${arrival_time}Z`);
@@ -42,24 +44,19 @@ router.post('/', async (req, res) => {
       },
       include: {
         places: true,
-        schedules: true
+        schedules: true,
       },
     });
     res.status(201).json(newSchedulePlace);
   } catch (err) {
-    res.status(500).json({ error: '新增資料時發生錯誤', details: err.message });
+    res.status(500).json({ error: "新增資料時發生錯誤", details: err.message });
   }
 });
 
-router.put('/:id', async (req, res) => {
+router.put("/:id", async (req, res) => {
   const { id } = req.params;
-  const {
-    which_date,
-    arrival_time,
-    stay_time,
-    transportation_way,
-    order,
-  } = req.body;
+  const { which_date, arrival_time, stay_time, transportation_way, order } =
+    req.body;
   try {
     const updatedSchedulePlace = await prisma.schedule_places.update({
       where: {
@@ -79,11 +76,11 @@ router.put('/:id', async (req, res) => {
     });
     res.status(200).json(updatedSchedulePlace);
   } catch (err) {
-    res.status(500).json({ error: '更新資料時發生錯誤', details: err.message });
+    res.status(500).json({ error: "更新資料時發生錯誤", details: err.message });
   }
 });
 
-router.delete('/:id', async (req, res) => {
+router.delete("/:id", async (req, res) => {
   const { id } = req.params;
   try {
     const deletedSchedulePlace = await prisma.schedule_places.delete({
@@ -92,15 +89,15 @@ router.delete('/:id', async (req, res) => {
       },
     });
     res.status(200).json({
-      message: '資料刪除成功',
+      message: "資料刪除成功",
       deletedSchedulePlace,
     });
   } catch (err) {
     res.status(500).json({
-      error: '刪除資料時發生錯誤',
+      error: "刪除資料時發生錯誤",
       details: err.message,
     });
   }
 });
 
-export  {router};
+export { router };

--- a/src/routes/schedulePlaces.js
+++ b/src/routes/schedulePlaces.js
@@ -1,11 +1,11 @@
 import express from "express";
 import { prisma } from "../configs/db.js";
-import { authenticate } from "../middlewares/auth.js";
+import { authenticator as authenticate } from "../middlewares/authenticator.js";
 import { verifyOwner } from "../middlewares/verifyOwner.js";
 
 const router = express.Router();
 
-router.get("/", async (req, res) => {
+router.get("/", authenticate, async (req, res) => {
   try {
     const schedulePlaces = await prisma.schedule_places.findMany({
       include: {
@@ -19,8 +19,37 @@ router.get("/", async (req, res) => {
   }
 });
 
+// 獲取特定日期的景點
+router.get("/byDate/:scheduleId/:date", async (req, res) => {
+  const { scheduleId, date } = req.params;
+
+  try {
+    const places = await prisma.schedule_places.findMany({
+      where: {
+        schedule_id: parseInt(scheduleId),
+        which_date: new Date(date),
+      },
+      include: {
+        places: true,
+      },
+      orderBy: {
+        position: "asc",
+      },
+    });
+
+    res.status(200).json(places);
+  } catch (error) {
+    console.error("Error fetching places by date:", error);
+    res.status(500).json({
+      error: "獲取景點資料失敗",
+      details: error.message,
+    });
+  }
+});
+
 router.post("/", async (req, res) => {
   const {
+    id,
     place_id,
     schedule_id,
     which_date,
@@ -28,55 +57,85 @@ router.post("/", async (req, res) => {
     stay_time,
     transportation_way,
     order,
+    position,
   } = req.body;
-  try {
-    const arrivalDateTime = new Date(`${which_date}T${arrival_time}Z`);
-    const stayDuration = new Date(`1970-01-01T${stay_time}Z`);
-    const newSchedulePlace = await prisma.schedule_places.create({
-      data: {
-        place_id,
-        schedule_id,
-        which_date: new Date(which_date),
-        arrival_time: arrivalDateTime,
-        stay_time: stayDuration,
-        transportation_way,
-        order: order.toString(),
-      },
-      include: {
-        places: true,
-        schedules: true,
-      },
-    });
-    res.status(201).json(newSchedulePlace);
-  } catch (err) {
-    res.status(500).json({ error: "新增資料時發生錯誤", details: err.message });
-  }
-});
 
-router.put("/:id", async (req, res) => {
-  const { id } = req.params;
-  const { which_date, arrival_time, stay_time, transportation_way, order } =
-    req.body;
   try {
-    const updatedSchedulePlace = await prisma.schedule_places.update({
-      where: {
-        id: parseInt(id),
-      },
-      data: {
-        which_date: new Date(which_date),
-        arrival_time: new Date(`${which_date}T${arrival_time}Z`),
-        stay_time: new Date(`1970-01-01T${stay_time}Z`),
-        transportation_way,
-        order: order.toString(),
-      },
-      include: {
-        places: true,
-        schedules: true,
-      },
+    // 開啟事務處理
+    await prisma.$transaction(async (prisma) => {
+      // 1. 獲取該日期的所有景點
+      const existingPlaces = await prisma.schedule_places.findMany({
+        where: {
+          schedule_id,
+          which_date: new Date(which_date),
+        },
+        orderBy: {
+          position: "asc",
+        },
+      });
+      // 2. 更新受影響景點的 position
+      if (!id) {
+        // 只在新增時調整其他景點的位置
+        await Promise.all(
+          existingPlaces
+            .filter((place) => place.position >= position)
+            .map((place) =>
+              prisma.schedule_places.update({
+                where: { id: place.id },
+                data: {
+                  position: {
+                    increment: 1,
+                  },
+                },
+              })
+            )
+        );
+      }
+
+      const upsertedSchedulePlace = await prisma.schedule_places.upsert({
+        where: {
+          id: id ?? -1, // 使用 -1，確定 id 不存在時應直接進行 create
+        },
+        update: {
+          ...(place_id && { place_id }),
+          ...(schedule_id && { schedule_id }),
+          ...(which_date && { which_date: new Date(which_date) }),
+          ...(arrival_time && {
+            arrival_time: new Date(`${which_date}T${arrival_time}Z`),
+          }),
+          ...(stay_time && { stay_time: new Date(`1970-01-01T${stay_time}Z`) }),
+          ...(transportation_way && { transportation_way }),
+          ...(order && { order: order.toString() }),
+          ...(position !== undefined && { position }),
+        },
+        create: {
+          place_id,
+          schedule_id,
+          which_date: new Date(which_date),
+          arrival_time: arrival_time
+            ? new Date(`${which_date}T${arrival_time}Z`)
+            : null,
+          stay_time: stay_time ? new Date(`1970-01-01T${stay_time}Z`) : null,
+          transportation_way: transportation_way || "Customize",
+          order: order?.toString() || Date.now().toString(),
+          position: position || 0,
+        },
+        include: {
+          places: true,
+          schedules: true,
+        },
+      });
+
+      return upsertedSchedulePlace;
     });
-    res.status(200).json(updatedSchedulePlace);
+
+    res.status(200).json({ message: "操作成功" });
   } catch (err) {
-    res.status(500).json({ error: "更新資料時發生錯誤", details: err.message });
+    console.error("Error:", err);
+    res.status(500).json({
+      error: "更新或新增資料時發生錯誤",
+      details: err.message,
+    });
   }
 });
 

--- a/src/routes/schedules.js
+++ b/src/routes/schedules.js
@@ -71,7 +71,6 @@ router.post("/", authenticate, async (req, res) => {
       start_date,
       end_date,
       transportation_way,
-      places,
     } = req.body;
 
     const userId = req.user.id;
@@ -90,12 +89,12 @@ router.post("/", authenticate, async (req, res) => {
         start_date: formattedStartDate,
         end_date: formattedEndDate,
         transportation_way,
-        schedule_places: {
-          create: places.map((placeId) => ({
-            place_id: placeId,
-            which_date: formattedStartDate,
-          })),
-        },
+        // schedule_places: {
+        //   create: places.map((placeId) => ({
+        //     place_id: placeId,
+        //     which_date: formattedStartDate,
+        //   })),
+        // },
       },
     });
 

--- a/src/routes/schedules.js
+++ b/src/routes/schedules.js
@@ -13,6 +13,13 @@ router.get("/", authenticate, async (req, res) => {
 
     const rows = await prisma.schedules.findMany({
       where: { create_by: userId },
+      include: {
+        schedule_places: {
+          include: {
+            places: true,
+          },
+        },
+      },
     });
 
     if (rows.length === 0) {
@@ -26,8 +33,29 @@ router.get("/", authenticate, async (req, res) => {
 });
 
 // 尋找單一行程（只能找到自己的，只是為了把每個schedule編號用）
-router.get("/:id", authenticate, verifyOwner("schedules"), (req, res) => {
-  res.status(200).json(req.resource);
+router.get("/:id", authenticate, verifyOwner("schedules"), async (req, res) => {
+  try {
+    const scheduleId = parseInt(req.params.id);
+
+    const schedule = await prisma.schedules.findUnique({
+      where: { id: scheduleId },
+      include: {
+        schedule_places: {
+          include: {
+            places: true,
+          },
+        },
+      },
+    });
+
+    if (!schedule) {
+      return res.status(404).json({ message: "找不到該行程" });
+    }
+
+    res.status(200).json(schedule);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
 });
 
 // 讓登入的用戶一自己的身份建立新行程
@@ -43,6 +71,7 @@ router.post("/", authenticate, async (req, res) => {
       start_date,
       end_date,
       transportation_way,
+      places,
     } = req.body;
 
     const userId = req.user.id;
@@ -50,7 +79,7 @@ router.post("/", authenticate, async (req, res) => {
     const formattedStartDate = new Date(`${start_date}T00:00:00.000Z`);
     const formattedEndDate = new Date(`${end_date}T00:00:00.000Z`);
 
-    await prisma.schedules.create({
+    const newSchedule = await prisma.schedules.create({
       data: {
         title,
         create_by: userId,
@@ -61,10 +90,16 @@ router.post("/", authenticate, async (req, res) => {
         start_date: formattedStartDate,
         end_date: formattedEndDate,
         transportation_way,
+        schedule_places: {
+          create: places.map((placeId) => ({
+            place_id: placeId,
+            which_date: formattedStartDate,
+          })),
+        },
       },
     });
 
-    res.status(201).json({ message: "成功建立新行程" });
+    res.status(201).json({ message: "成功建立新行程", newSchedule });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -84,6 +119,7 @@ router.patch(
         start_date,
         end_date,
         transportation_way,
+        places,
       } = req.body;
 
       const formattedStartDate = start_date
@@ -105,7 +141,41 @@ router.patch(
           ...(transportation_way && { transportation_way }),
         },
       });
-
+      // 如果傳入 `places`，則更新 schedule_places 資料
+      if (places && places.length > 0) {
+        for (const place of places) {
+          await prisma.schedule_places.upsert({
+            where: {
+              schedule_id_place_id: {
+                schedule_id: req.resource.id,
+                place_id: place.place_id,
+              },
+            },
+            update: {
+              which_date: new Date(place.which_date),
+              arrival_time: place.arrival_time
+                ? new Date(place.arrival_time)
+                : null,
+              stay_time: place.stay_time ? new Date(place.stay_time) : null,
+              transportation_way:
+                place.transportation_way || "PUBLIC_TRANSPORT",
+              order: place.order,
+            },
+            create: {
+              schedule_id: req.resource.id,
+              place_id: place.place_id,
+              which_date: new Date(place.which_date),
+              arrival_time: place.arrival_time
+                ? new Date(place.arrival_time)
+                : null,
+              stay_time: place.stay_time ? new Date(place.stay_time) : null,
+              transportation_way:
+                place.transportation_way || "PUBLIC_TRANSPORT",
+              order: place.order,
+            },
+          });
+        }
+      }
       res.status(200).json({
         message: "行程更新成功",
         updatedSchedule,


### PR DESCRIPTION
**調整GET http://localhost:3000/schedules/ 返回行程中所有日期以及對應景點的細項資料**
![image](https://github.com/user-attachments/assets/de45e4d3-bb14-49e7-86a7-ea9adf85a8fa)

**調整POST http://localhost:3000/schedulePlaces/ 業務邏輯，設定景點順序(order)，以便存放景點至欲擺放位置，存取新景點自動呼叫update修改原本order位置；另合併update與create成upsert統一管理。**
![image](https://github.com/user-attachments/assets/9c40ae25-2a59-4a9b-8509-ed85a1f1a39d)

**新增GET http://localhost:3000/byDate/:scheduleId/:date API ，可透過行程id以及當天日期取得當日所有景點，方便前端頁面渲染**
![image](https://github.com/user-attachments/assets/93769fad-2c53-4f13-b6c0-73aed1b90b4b)

