### PR TITLE
feat: LinePay 金流功能 v2 完成版

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,6 +124,7 @@ model users {
   create_at       DateTime?         @default(now()) @db.Timestamp(0)
   token           String?           @db.VarChar(511)
   token_time      DateTime          @default(now()) @updatedAt @db.Timestamp(0)
+  level           String?           @db.VarChar(45)
   favorites       favorites[]
   users_bills     users_bills[]
   users_images    users_images[]

--- a/src/routes/payment.js
+++ b/src/routes/payment.js
@@ -3,23 +3,46 @@ import dotenv from "dotenv";
 import axios from "axios";
 import Base64 from 'crypto-js/enc-base64.js';
 import hmacSHA256 from 'crypto-js/hmac-sha256.js';
+import { PrismaClient } from "@prisma/client";
 
+const prisma = new PrismaClient();
 dotenv.config();
 const router = express.Router();
-const { LINEPAY_CHANNELID, LINEPAY_SECRET, LINEPAY_VERSION, LINEPAY_SITE, LINEPAY_RETURN_HOST, LINEPAY_RETURN_CONFIRM_URL, LINEPAY_RETURN_CANCEL_URL } = process.env;
+const { LINEPAY_CHANNELID, LINEPAY_SECRET, LINEPAY_VERSION, LINEPAY_SITE, HOST_URL, LINEPAY_RETURN_CONFIRM_URL, LINEPAY_RETURN_CANCEL_URL } = process.env;
+
+function createSignature(uri, orders) {
+  const nonce = parseInt(new Date().getTime() / 1000);
+  const string = `${LINEPAY_SECRET}/${LINEPAY_VERSION}${uri}${JSON.stringify(orders)}${nonce}`;
+  const signature = Base64.stringify(hmacSHA256(string, LINEPAY_SECRET));
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-LINE-ChannelId': LINEPAY_CHANNELID,
+    'X-LINE-Authorization-Nonce': nonce,
+    'X-LINE-Authorization': signature
+  };
+  return headers;
+}
 
 const orders = {}
+let productAmount
+let productCurrency
+let level
+let user_Id
 router.post('/', async (req, res) => {
   try {
-    const { amount, currency, packages } = req.body;
+    const { amount, currency, packages, userId } = req.body;
+    productAmount = amount;
+    productCurrency = currency;
+    level = packages[0].products[0].name
+    user_Id = userId
     const order = {
       amount,
       currency,
       packages,
       orderId: parseInt(new Date().getTime() / 1000),
       redirectUrls: {
-        confirmUrl: `${LINEPAY_RETURN_HOST}${LINEPAY_RETURN_CONFIRM_URL}`,
-        cancelUrl: `${LINEPAY_RETURN_HOST}${LINEPAY_RETURN_CANCEL_URL}`
+        confirmUrl: `${LINEPAY_RETURN_CONFIRM_URL}`,
+        cancelUrl: `${LINEPAY_RETURN_CANCEL_URL}`
       }
     }
     orders[order.orderId] = order;
@@ -38,39 +61,33 @@ router.post('/', async (req, res) => {
   }
 })
 
-
 router.get('/confirm', async (req, res) => {
-  const { transactionId, orderId } = req.query // 錯誤提示看起來是抓不到 transactionId
   try {
-    const order = orders[orderId]
+    const { transactionId } = req.query 
     const linePayBody = {
-      amount: 60,
-      currency: 'TWD',
+      amount: productAmount,
+      currency: productCurrency,
     }
     const uri = `/payments/${transactionId}/confirm`
     const headers = createSignature(uri, linePayBody);
     const url = `${LINEPAY_SITE}/${LINEPAY_VERSION}${uri}`
     const linePayRes = await axios.post(url, linePayBody, { headers });
-    console.log(linePayRes);
-    res.json({ message: 'LinePay success' })
-  } catch (error) {
-    res.status(500).json({
-      message: error.message
+  
+    if (linePayRes?.data?.returnCode === '0000') {
+      res.redirect(`${HOST_URL}/member?order=${transactionId}`);
+    } 
+    await prisma.users.update({
+      where: { id: parseInt(user_Id) },
+      data: {
+        ...(level && { level }),
+      }
     })
+  } catch (error) {
+    res.status(500).send({
+      message: error,
+    });
   }
 })
 
-export { router }
 
-function createSignature(uri, orders) {
-  const nonce = parseInt(new Date().getTime() / 1000);
-  const string = `${LINEPAY_SECRET}/${LINEPAY_VERSION}${uri}${JSON.stringify(orders)}${nonce}`;
-  const signature = Base64.stringify(hmacSHA256(string, LINEPAY_SECRET));
-  const headers = {
-    'Content-Type': 'application/json',
-    'X-LINE-ChannelId': LINEPAY_CHANNELID,
-    'X-LINE-Authorization-Nonce': nonce,
-    'X-LINE-Authorization': signature
-  };
-  return headers;
-}
+export { router }


### PR DESCRIPTION
- 有**更新資料庫** users 表格新增 level 欄位，成功付款後，會將會員等級存進資料庫 level 欄位。
前端詳細流程可參考[此票](https://github.com/fontend-team4/TriPuzzle/pull/133)
- 有**更新環境變數**：
LINEPAY_CHANNELID=
LINEPAY_SECRET=
LINEPAY_VERSION=
LINEPAY_SITE=
LINEPAY_RETURN_CONFIRM_URL=
LINEPAY_RETURN_CANCEL_URL=

- 可以抓到前端點擊的對應會員等級名稱與價格，並完成付款。
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ce4ab4cd-5c72-4278-b7d7-755efa2cd28b" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/069dd0a7-f2e9-4ef0-831f-897702d2d2fa" />
